### PR TITLE
added plugin to list kernel modules

### DIFF
--- a/plugins/kernel_modules.rb
+++ b/plugins/kernel_modules.rb
@@ -1,0 +1,15 @@
+# Encoding: UTF-8
+
+Ohai.plugin(:KernelModules) do
+  provides 'kernel_modules'
+
+  collect_data(:linux) do
+    kernel_modules Mash.new
+    r_fd = File.open('/proc/modules', 'r')
+    r_fd.each_line do |line|
+      line = line.split(/\s+/)
+      kernel_modules[line[0]] = { state: line[4],
+                                  depends: line[3].split(',') }
+    end
+  end
+end

--- a/test/integration/ohaiplugins/serverspec/localhost/kernel_modules_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/kernel_modules_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+kernel_modules = OHAI['kernel_modules']
+
+describe 'kernel_modules plugin' do
+
+  it 'should be composed of hashes' do
+    expect(kernel_modules['ip_tables']).to be_a(Hash)
+  end
+
+  it 'should have state Live' do
+    expect(kernel_modules['ip_tables'][:state]).to eql('Live')
+  end
+
+  it 'should have dependencies' do
+    expect(kernel_modules['ip_tables'][:depends]).to eql([ 'iptable_filter' ])
+  end
+
+end
+  


### PR DESCRIPTION
Added plugin and tests.

The existing tests seem to fail (though mine pass):

`       rspec /tmp/busser/suites/serverspec/localhost/installed_services_spec.rb:18 # InstalledServices Plugin should have a value for init
       rspec /tmp/busser/suites/serverspec/localhost/iptables_spec.rb:7 # Ip_tables Plugin should be a Mash
       rspec /tmp/busser/suites/serverspec/localhost/iptables_spec.rb:11 # Ip_tables Plugin should contain rules
       rspec /tmp/busser/suites/serverspec/localhost/magento_spec.rb:6 # Magento Plugin should be a hash
       rspec /tmp/busser/suites/serverspec/localhost/magento_spec.rb:10 # Magento Plugin should report vhost
       rspec /tmp/busser/suites/serverspec/localhost/magento_spec.rb:14 # Magento Plugin should report path
       rspec /tmp/busser/suites/serverspec/localhost/magento_spec.rb:19 # Magento Plugin should report version
       rspec /tmp/busser/suites/serverspec/localhost/postfix_spec.rb:73 # Postfix Plugin should have postfix command
       rspec /tmp/busser/suites/serverspec/localhost/rackconnect_spec.rb:9 # Rackconnect Plugin should have the rackconnect enabled key
       rspec /tmp/busser/suites/serverspec/localhost/rhcs_spec.rb:12 # RHCS Plugin should be an array
       rspec /tmp/busser/suites/serverspec/localhost/rhcs_spec.rb:16 # RHCS Plugin should have a value
       rspec /tmp/busser/suites/serverspec/localhost/rhcs_spec.rb:20 # RHCS Plugin should be an array
       rspec /tmp/busser/suites/serverspec/localhost/rhcs_spec.rb:24 # RHCS Plugin should have a value
       rspec /tmp/busser/suites/serverspec/localhost/sysctl_spec.rb:6 # sysctl Plugin should return a number of keys from the system`
