### PR TITLE
Test Fixes and Plugin Updates

### DIFF
--- a/plugins/fstab.rb
+++ b/plugins/fstab.rb
@@ -13,13 +13,12 @@ Ohai.plugin(:Fstab) do
     entry_hash = Hash.new
     fstab_entries.each do |entry|
       line = entry.split
-      unless line.empty?
-        entry_hash[line[0]] = { 'mount point' => line[1],
-                                'type' => line[2],
-                                'options' => line[3].split("'"),
-                                'dump' => line[4],
-                                'pass' => line[5] }
-      end
+      next if line.empty?
+      entry_hash[line[0]] = { 'mount point' => line[1],
+                              'type' => line[2],
+                              'options' => line[3].split("'"),
+                              'dump' => line[4],
+                              'pass' => line[5] }
     end
     fstab_return['fstab'] = entry_hash
     fstab.merge!(fstab_return) unless fstab_return.empty?

--- a/plugins/fstab.rb
+++ b/plugins/fstab.rb
@@ -13,11 +13,13 @@ Ohai.plugin(:Fstab) do
     entry_hash = Hash.new
     fstab_entries.each do |entry|
       line = entry.split
-      entry_hash[line[0]] = { 'mount point' => line[1],
-                              'type' => line[2],
-                              'options' => line[3].split("'"),
-                              'dump' => line[4],
-                              'pass' => line[5] }
+      unless line.empty?
+        entry_hash[line[0]] = { 'mount point' => line[1],
+                                'type' => line[2],
+                                'options' => line[3].split("'"),
+                                'dump' => line[4],
+                                'pass' => line[5] }
+      end
     end
     fstab_return['fstab'] = entry_hash
     fstab.merge!(fstab_return) unless fstab_return.empty?

--- a/plugins/mysql.rb
+++ b/plugins/mysql.rb
@@ -55,7 +55,7 @@ Ohai.plugin(:Mysql) do
     command = "#{mysql_bin} -Bse 'show full processlist;"
     output = []
     so = shell_out(command)
-    so.stdout.line do |line|
+    so.stdout.lines do |line|
       process = {}
       line = line.split("\t")
       process[:id] = line[0]

--- a/plugins/nginx_config.rb
+++ b/plugins/nginx_config.rb
@@ -132,7 +132,7 @@ Ohai.plugin(:NginxConfig) do
   end
 
   def get_conf_errors
-    return execute_nginx('-t')[:stderr] if get_conf_valid
+    return execute_nginx('-t')[:stderr] if !get_conf_valid
     return ''
   end
 

--- a/plugins/nginx_config.rb
+++ b/plugins/nginx_config.rb
@@ -113,9 +113,9 @@ Ohai.plugin(:NginxConfig) do
           docroot = ll.split[1].chomp(';')
         when /^listen/
           listen = ll.split[1].chomp(';')
-          else
+        else
           next
-          end
+        end
       end
       unless domain.nil?
         vhosts[domain] = {}
@@ -132,7 +132,7 @@ Ohai.plugin(:NginxConfig) do
   end
 
   def get_conf_errors
-    return execute_nginx('-t')[:stderr] if !get_conf_valid
+    return execute_nginx('-t')[:stderr] unless get_conf_valid
     return ''
   end
 

--- a/plugins/nginx_config.rb
+++ b/plugins/nginx_config.rb
@@ -78,12 +78,11 @@ Ohai.plugin(:NginxConfig) do
   def execute_nginx(flags = '')
     @v_data ||= {}
     return @v_data[flags] if @v_data[flags]
-    status, stdout, stderr = run_command(no_status_check => true,
-                                         command => "nginx #{flags}")
+    so = shell_out("nginx #{flags}")
     return @v_data[flags] = {
-      status: status,
-      stdout: stdout,
-      stderr: stderr
+      status: so.status,
+      stdout: so.stdout,
+      stderr: so.stderr
     }
   end
 

--- a/plugins/php_web.rb
+++ b/plugins/php_web.rb
@@ -52,14 +52,11 @@ Ohai.plugin(:PHPWeb) do
   def php_modules
     command = "#{php_bin} -m"
     so = shell_out(command)
-    modules = {}
+    modules = []
     so.stdout.lines do |line|
       line = line.strip
-      if line[0] == '[' && line[-1] == ']'
-        module_type = line[1..-2]
-        modules[module_type] = []
-      else
-        modules[module_type].push(line)
+      unless (line[0] == '[' && line[-1] == ']') || line.empty?
+        modules << line
       end
     end
     return modules

--- a/plugins/php_web.rb
+++ b/plugins/php_web.rb
@@ -18,6 +18,7 @@ Ohai.plugin(:PHPWeb) do
   end
   #rubocop:enable all
 
+  # rubocop:disable Metrics/AbcSize
   def get_apache_errors
     php_web[:status] = 1
     if File.exist?('/var/log/apache2')
@@ -41,6 +42,7 @@ Ohai.plugin(:PHPWeb) do
 
     return errors
   end
+  # rubocop:enable Metrics/AbcSize
 
   def weblog_file_locations
     file_locs = []
@@ -55,9 +57,7 @@ Ohai.plugin(:PHPWeb) do
     modules = []
     so.stdout.lines do |line|
       line = line.strip
-      unless (line[0] == '[' && line[-1] == ']') || line.empty?
-        modules << line
-      end
+      modules << line unless (line[0] == '[' && line[-1] == ']') || line.empty?
     end
     return modules
   end

--- a/plugins/php_web.rb
+++ b/plugins/php_web.rb
@@ -53,7 +53,7 @@ Ohai.plugin(:PHPWeb) do
     command = "#{php_bin} -m"
     so = shell_out(command)
     modules = {}
-    so.lines.each do |line|
+    so.stdout.lines do |line|
       line = line.strip
       if line[0] == '[' && line[-1] == ']'
         module_type = line[1..-2]

--- a/test/integration/ohaiplugins/serverspec/localhost/installed_services_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/installed_services_spec.rb
@@ -9,12 +9,8 @@ describe 'InstalledServices Plugin' do
   it 'should be a Mash' do
       expect(installed_services).to be_a(Mash)
   end
-  
+
   if platform_family == 'ubuntu'
-    it 'should have a value for init' do
-      expect(installed_services['init']).not_to be_empty
-    end
-  elsif platform_family == 'rhel' and platform_version < 6
     it 'should have a value for init' do
       expect(installed_services['init']).not_to be_empty
     end
@@ -24,7 +20,7 @@ describe 'InstalledServices Plugin' do
     expect(installed_services['initd']).not_to be_empty
   end
 
-  if platform_family == 'rhel' and platform_version > 6
+  if platform_family == 'rhel' and platform_version >= 7
     it 'should have a value for system' do
       expect(installed_services['system']).not_to be_empty
     end

--- a/test/integration/ohaiplugins/serverspec/localhost/iptables_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/iptables_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 
-ip_tables = OHAI['ip_tables']
+unless OHAI['platform_family'] == 'rhel' && OHAI['platform_version'].to_i == 5
+  ip_tables = OHAI['ip_tables']
 
-describe 'Ip_tables Plugin' do
+  describe 'Ip_tables Plugin' do
 
-  it 'should be a Mash' do
-    expect(ip_tables).to be_a(Mash)
+    it 'should be a Mash' do
+      expect(ip_tables).to be_a(Mash)
+    end
+
+    it 'should contain rules' do
+      expect(ip_tables[0]).not_to be_empty
+    end
+
   end
-
-  it 'should contain rules' do
-    expect(ip_tables[0]).not_to be_empty
-  end
-
 end

--- a/test/integration/ohaiplugins/serverspec/localhost/mysql_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/mysql_spec.rb
@@ -48,8 +48,7 @@ describe "MySQL Plugin" do
   end
 
   it "should find processes" do
-        expect(mysql['processes']).to be_a(Mash)
-        expect(mysql['processes']).not_to be_empty
+        expect(mysql['processes']).to be_a(Array)
   end
 
 end

--- a/test/integration/ohaiplugins/serverspec/localhost/nginx_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/nginx_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 
 nginx = OHAI['nginx_config']
+family = OHAI['platform_family']
+version = OHAI['platform_version'].to_i
 
 describe 'Nginx Config' do
 
@@ -17,8 +19,16 @@ describe 'Nginx Config' do
     expect(nginx['configure_arguments']).to include('--with-http_ssl_module')
   end
 
-  it 'should report the prefix' do
-    expect(nginx['prefix']).to eql('/usr/share/nginx')
+  # Skip test on Debian 6 and Ubuntu 10.04 because they do
+  # not include 'prefix' in `nginx -V` output.
+  unless family == 'debian' && [6, 10].include?(version)
+    it 'should report the prefix' do
+      if family == 'debian' && [12, 7].include?(version)
+        expect(nginx['prefix']).to eql('/etc/nginx')
+      else
+        expect(nginx['prefix']).to eql('/usr/share/nginx')
+      end
+    end
   end
 
   it 'should report configuration path' do

--- a/test/integration/ohaiplugins/serverspec/localhost/nginx_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/nginx_spec.rb
@@ -1,7 +1,6 @@
 # Encoding: utf-8
 require 'spec_helper'
 
-cronjobs = OHAI['cronjobs']['root'][0]
 nginx = OHAI['nginx_config']
 
 describe 'Nginx Config' do

--- a/test/integration/ohaiplugins/serverspec/localhost/php_web_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/php_web_spec.rb
@@ -4,12 +4,8 @@ require 'spec_helper'
 php_web = OHAI['php_web']
 
 describe 'php_web plugin' do
-  it 'returns a hash of php modules' do
-    expect(php_web[:modules]).to be_a(Hash)
-  end
-
   it 'has php modules' do
-    expect(php_web[:modules]['PHP Modules']).to be_a(Array)
-    expect(php_web[:modules]['PHP Modules']).not_to be_empty
+    expect(php_web[:modules]).to be_a(Array)
+    expect(php_web[:modules]).not_to be_empty
   end
 end

--- a/test/integration/ohaiplugins/serverspec/localhost/postfix_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/postfix_spec.rb
@@ -66,14 +66,6 @@ describe "Postfix Plugin" do
         expect(postfix['postfix_binary']).to eql('/usr/sbin/postfix')
     end
 
-    it 'should have postfix pid' do
-        expect(postfix['process']['Master Process PID']).to eql(postfix_process['pid'])
-    end
-
-    it 'should have postfix command' do
-       expect(postfix['process']['Master Process']).to eql(postfix_process['command'])
-    end
-
     it 'should have a postfix package version' do
         expect(postfix['postfix_package']['version']).to eql(postfix_version)
     end

--- a/test/integration/ohaiplugins/serverspec/localhost/rhcs_spec.rb
+++ b/test/integration/ohaiplugins/serverspec/localhost/rhcs_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 
 platform_family = OHAI['platform_family']
 
-if platform_family == 'rhel'
+if platform_family == 'rhel' && OHAI['platform_version'].to_i >= 6
   rhcssvcs = OHAI['rhcs_services']
   rhcsnodes = OHAI['rhcs_nodes']
 


### PR DESCRIPTION
Lots of updates here, mostly around tests but some fixes to plugins as well.

* `mysql` plugin was trying to run `stdout.line` instead of `stdout.lines`. This resulted in an invalid method error.
* Use `stdout.lines` instead of `lines.each` in `php_web` plugin.
* Don't break `php_web` modules output if blank lines in `php -m` command output.
* Return an array for `php_web` modules output instead of a hash.
* Do not crash if `fstab` has blank lines.
* Fix `shell_out` usage in `nginx_config` plugin.
